### PR TITLE
🚢 K8s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
+        exclude: k8s/.*\.yaml
       - id: debug-statements
       - id: check-builtin-literals
       - id: check-case-conflict

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,36 @@
+# k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fastapi-web
+  template:
+    metadata:
+      labels:
+        app: fastapi-web
+    spec:
+      containers:
+        - name: fastapi
+          image: fastapi-k8s:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              value: mongodb://mongo:27017/test_db
+            - name: SECRET_KEY
+              value: your-secret-key
+            - name: ALGORITHM
+              value: HS256
+            - name: ACCESS_TOKEN_EXPIRE_MINUTES
+              value: "30"
+            - name: CELERY_BROKER_URL
+              value: redis://redis:6379/0
+            - name: CELERY_RESULT_BACKEND
+              value: redis://redis:6379/0
+          command: ["uvicorn"]
+          args: ["app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/k8s/mongo.yaml
+++ b/k8s/mongo.yaml
@@ -1,0 +1,21 @@
+# k8s/mongo.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mongo
+spec:
+  containers:
+    - name: mongo
+      image: mongo:6
+      ports:
+        - containerPort: 27017
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+spec:
+  ports:
+    - port: 27017
+  selector:
+    app: mongo

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,21 @@
+# k8s/redis.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+spec:
+  containers:
+    - name: redis
+      image: redis:7
+      ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: redis

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+# k8s/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fastapi-service
+spec:
+  selector:
+    app: fastapi-web
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: NodePort


### PR DESCRIPTION
## 📜 Add Kubernetes Manifests

This PR introduces the required Kubernetes manifests to deploy the application in a local or remote cluster. Included files:

- `mongo.yaml`: Deployment and Service for MongoDB
- `redis.yaml`: Deployment and Service for Redis
- `fastapi-web.yaml`: Deployment for the FastAPI app
- `fastapi-service.yaml`: NodePort Service to expose the FastAPI app

These manifests are placed in the `k8s/` directory and can be applied using:

```bash
kubectl apply -f k8s/
```
Note: Ensure that the image used in fastapi-web.yaml is accessible (e.g., pushed to Docker Hub or another registry).

## 🧪 How to test locally

> Assumes you're using **macOS** with **Docker** and **Minikube**.

1. Start a local Kubernetes cluster:
```bash
minikube start --driver=docker
```
2. Apply the manifests:

```bash
kubectl apply -f k8s/
```

3. Expose the FastAPI service locally:

```bash
minikube service fastapi-service --url
```

Visit the URL printed in your terminal in the browser to access the FastAPI app.